### PR TITLE
[API-51] Add contract and businessId validation

### DIFF
--- a/server/services/factory/factoryService.js
+++ b/server/services/factory/factoryService.js
@@ -1,5 +1,14 @@
 const _ = require('lodash');
 
+const buildDuplicationErrorMessage = (err, field) => {
+  if (err.message.includes(field)) {
+    _.merge(err, {
+      message: `A factory with this ${field} already exists.`,
+    });
+    throw err;
+  }
+};
+
 const factoryService = ({ store }) => {
   const { Factory } = store.models;
 
@@ -19,8 +28,11 @@ const factoryService = ({ store }) => {
         ]),
       )
       .catch(err => {
-        if (err.code === 11000)
-          _.merge(err, { message: 'A factory with this name already exists.' });
+        if (err.code === 11000) {
+          buildDuplicationErrorMessage(err, 'name');
+          buildDuplicationErrorMessage(err, 'businessId');
+          buildDuplicationErrorMessage(err, 'contract');
+        }
         throw err;
       });
 

--- a/tests/integration/factory.integration.test.js
+++ b/tests/integration/factory.integration.test.js
@@ -128,16 +128,52 @@ describe('Factory API', () => {
       });
   });
 
-  it('Should throw an error when try to create the same factory more than once', async done => {
+  it('Should throw A factory with this name already exists when try to create a factory with an existing name', async done => {
     const factory = factorySeed.getNextFactory();
+    const newFactory = factorySeed.getNextFactory();
     await createFactory(factory);
-    await post(app, '/api/factories', factory, loggedUser.token)
+    newFactory.name = factory.name;
+    await post(app, '/api/factories', newFactory, loggedUser.token)
       .expect(403)
       .then(response => {
         expect(response.body).toBeDefined();
         expect(response.body.error).toBeDefined();
         expect(response.body.error.message).toEqual(
           'A factory with this name already exists.',
+        );
+        done();
+      });
+  });
+
+  it('Should throw A factory with this businessId already exists when try to create a factory with an existing businessId', async done => {
+    const factory = factorySeed.getNextFactory();
+    const newFactory = factorySeed.getNextFactory();
+    await createFactory(factory);
+    newFactory.businessId = factory.businessId;
+    await post(app, '/api/factories', newFactory, loggedUser.token)
+      .expect(403)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body.error).toBeDefined();
+        expect(response.body.error.message).toEqual(
+          'A factory with this businessId already exists.',
+        );
+        done();
+      });
+  });
+
+  it('Should throw A factory with this contract already exists when try to create a factory with an existing contract', async done => {
+    const factory = factorySeed.getNextFactory();
+    const newFactory = factorySeed.getNextFactory();
+    await createFactory(factory);
+    newFactory.contract = factory.contract;
+    await post(app, '/api/factories', newFactory, loggedUser.token)
+      .expect(403)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body.error).toBeDefined();
+        expect(response.body.error.message).toEqual(
+          'A factory with this contract already exists.',
         );
         done();
       });


### PR DESCRIPTION
## Story Tracking
API Card https://github.com/silvamarcel/DuplicaApi/issues/51

## Message
Add contract and businessId validation

## Breaking Changes
N/A
